### PR TITLE
feat(utils): Adds ClipboardText component to ease getting information from labels in UI

### DIFF
--- a/app/scripts/modules/core/src/utils/ClipboardText.tsx
+++ b/app/scripts/modules/core/src/utils/ClipboardText.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+export class ClipboardText extends React.Component<any> {
+  private textRef: React.RefObject<HTMLInputElement> = React.createRef();
+
+  private inputStyle = {
+    borderWidth: '0px',
+    backgroundColor: 'transparent',
+  };
+
+  public handleClick = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    const node: HTMLInputElement = this.textRef.current;
+    node.focus();
+    node.select();
+
+    try {
+      document.execCommand('copy');
+    } catch (e) {
+      /* don't do anything */
+    }
+  };
+
+  public render() {
+    const { text } = this.props;
+    return <input onClick={this.handleClick} ref={this.textRef} value={text} type="text" style={this.inputStyle} />;
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestStatus.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { IManifest } from '@spinnaker/core';
+import { ClipboardText } from 'core/utils/ClipboardText';
 import { DeployManifestStatusPills } from './DeployStatusPills';
 import { ManifestYaml } from './ManifestYaml';
 import { ManifestDetailsLink } from './ManifestDetailsLink';
@@ -20,7 +21,7 @@ export class ManifestStatus extends React.Component<IManifestStatusProps> {
       <dl className="manifest-status" key="manifest-status">
         <dt>{manifest.manifest.kind}</dt>
         <dd>
-          {manifest.manifest.metadata.name}
+          <ClipboardText text={manifest.manifest.metadata.name} />
           &nbsp;
           <DeployManifestStatusPills manifest={manifest} />
         </dd>


### PR DESCRIPTION
features:

- Adds `ClipboardText` component to be used in text-labels to make it easy to copy/paste information directly from the UI. 
- Example: https://cl.ly/493c95d5c56f

fixes:

"Double-Click to highlight is bad in Spinnaker" https://github.com/DataDog/engtools/issues/201

---

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
