### PR TITLE
execution-status: overflow hidden on both X and Y

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/executionStatus.less
+++ b/app/scripts/modules/core/src/pipeline/status/executionStatus.less
@@ -1,7 +1,7 @@
 .execution-status-section {
   display: inline-block;
   width: 180px;
-  overflow-y: hidden;
+  overflow: hidden;
   font-size: .8em;
   line-height: 12px;
   .status {


### PR DESCRIPTION

If the div is too long on the X axis, a scrollbar can appear. That scrollbar, in conjunction with the `overflow-y: hidden` results in the "detail" link being impossible to click on.


![image](https://user-images.githubusercontent.com/1613036/56130276-b9db7580-5f84-11e9-91d3-8066fe5806de.png)